### PR TITLE
update outdated .zip file link

### DIFF
--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
       <div class="span-12 last"> 
          <h3>Download the dataset</h3>
          <p>
-            The current, September 13, 2011 version of the dataset is available as a zip archive <a href="https://dl.dropboxusercontent.com/u/44891/research/VOCB3DO.zip">here</a>.
+            The current, September 13, 2011 version of the dataset is available as a zip archive <a href="https://www.dropbox.com/s/yzrjtc87tfcr2c1/VOCB3DO.zip?dl=1">here</a>.
             Results in the <a href="http://sergeykarayev.com/files/iccv2011.pdf">paper</a> refer to this version.
          </p>
       </div>


### PR DESCRIPTION
Dropbox recently ended support for Public folder links, an old feature. Update the link to the new format, or better yet, host the file elsewhere :)